### PR TITLE
Don’t require a new codelist to already be present

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ For example, if you need to scrape a web page to keep a codelist up to date, you
 Currently, this is the process:
 
 1. Make a codelist template: this is a codelist with none of the `codelist-item` elements. The easiest way to do this is to copy and rename one of the files in the `templates` folder.
-2. Add a the (empty) codelist template to the relevant repository (via a pull request).
-3. Add the same template to the `templates` folder. It must have the same name as the codelist template in step (2).
-4. Create an importer: you can start by copying and renaming an importer from the `importers` folder.
-5. Update `.travis.yml` to include your importer.
+2. Add the (empty) codelist template to the `templates` folder.
+3. Create an importer: you can start by copying and renaming an importer from the `importers` folder.
+4. Update `.travis.yml` to include your importer.

--- a/importers/helpers/__init__.py
+++ b/importers/helpers/__init__.py
@@ -156,23 +156,29 @@ def source_to_xml(tmpl_name, source_url, lookup,
     source_data_dict = OrderedDict([(source_data_row['code'].upper(), source_data_row) for source_data_row in source_data])
 
     old_codelist_els = old_xml.xpath('//codelist-item')
+    old_codelist_codes = [
+        old_codelist_el.find('code').text.upper()
+        for old_codelist_el in old_codelist_els]
+
     while True:
         if not old_codelist_els and not source_data_dict:
             break
-        if old_codelist_els:
-            old_codelist_el = old_codelist_els[0]
-            old_codelist_code = old_codelist_el.find('code').text.upper()
-        else:
-            old_codelist_code = None
+
         if source_data_dict:
             new_code_dict = list(source_data_dict.values())[0]
-            if new_code_dict['code'].upper() != old_codelist_code and not old_xml.xpath('//codelist-item/code[text()="{}"]/..'.format(new_code_dict['code'])):
+            if new_code_dict['code'].upper() not in old_codelist_codes:
                 # add a new code
                 new_codelist_item = create_codelist_item(new_code_dict.keys(), namespaces=namespaces)
                 new_codelist_item = update_codelist_item(new_codelist_item, new_code_dict, namespaces=namespaces)
                 codelist_items.append(new_codelist_item)
                 source_data_dict.popitem(last=False)
                 continue
+
+        if old_codelist_els:
+            old_codelist_el = old_codelist_els[0]
+            old_codelist_code = old_codelist_el.find('code').text.upper()
+        else:
+            old_codelist_code = None
 
         if old_codelist_code in source_data_dict:
             # it's in the current codes, so update it

--- a/importers/helpers/__init__.py
+++ b/importers/helpers/__init__.py
@@ -133,7 +133,18 @@ def reset_repo(tmpl_name, repo=None):
 def source_to_xml(tmpl_name, source_url, lookup,
                   repo=None, source_data=None, order_by=None):
     reset_repo(tmpl_name, repo)
-    old_xml = ET.parse(join('codelist_repo', 'xml', '{}.xml'.format(tmpl_name)), etparser)
+
+    try:
+        old_xml = ET.parse(
+            join('codelist_repo', 'xml', '{}.xml'.format(tmpl_name)),
+            etparser)
+        old_codelist_els = old_xml.xpath('//codelist-item')
+    except OSError:
+        old_codelist_els = []
+
+    old_codelist_codes = [
+        old_codelist_el.find('code').text.upper()
+        for old_codelist_el in old_codelist_els]
 
     tmpl_path = join('templates', '{}.xml'.format(tmpl_name))
     xml = ET.parse(tmpl_path, etparser)
@@ -154,11 +165,6 @@ def source_to_xml(tmpl_name, source_url, lookup,
         ]) for x in reader if x[code_lookup]]
 
     source_data_dict = OrderedDict([(source_data_row['code'].upper(), source_data_row) for source_data_row in source_data])
-
-    old_codelist_els = old_xml.xpath('//codelist-item')
-    old_codelist_codes = [
-        old_codelist_el.find('code').text.upper()
-        for old_codelist_el in old_codelist_els]
 
     while True:
         if not old_codelist_els and not source_data_dict:


### PR DESCRIPTION
This means when you create a new importer, you can just add the new template to this repo. There’s no need to add it as a placeholder to the codelist repo, too.