### PR TITLE
Include remaining UN M49 classifications for countries

### DIFF
--- a/importers/region_m49.py
+++ b/importers/region_m49.py
@@ -43,6 +43,10 @@ def run():
         ('codeforiati:intermediate-region-name_fr', 'Intermediate Region Name_FR'),
         ('codeforiati:intermediate-region-name_ru', 'Intermediate Region Name_RU'),
         ('codeforiati:intermediate-region-name_zh', 'Intermediate Region Name_ZH'),
+        ('codeforiati:least-developed-countries', 'Least Developed Countries (LDC)'),
+        ('codeforiati:land-locked-developing-countries', 'Land Locked Developing Countries (LLDC)'),
+        ('codeforiati:small-island-developing-states', 'Small Island Developing States (SIDS)'),
+        ('codeforiati:developed-developing', 'Developed / Developing Countries'),
     ]
     Importer('RegionM49', url, lookup, repo='Unofficial-Codelists')
 


### PR DESCRIPTION
Add remaining UNM49 classifications for countries.

Example of how this looks in the data (e.g. for Comoros):

```xml
<codeforiati:least-developed-countries>1</codeforiati:least-developed-countries>
<codeforiati:land-locked-developing-countries>0</codeforiati:land-locked-developing-countries>
<codeforiati:small-island-developing-states>1</codeforiati:small-island-developing-states>
<codeforiati:developed-developing>Developing</codeforiati:developed-developing>
```