### PR TITLE
Rearrange DAC Sector Groups codelist columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /codelist_repo/
+.DS_Store
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/importers/sector_groups.py
+++ b/importers/sector_groups.py
@@ -10,9 +10,9 @@ def run():
         ('codeforiati:category-code', 'category_code'),
         ('codeforiati:category-name_en', 'category_name_en'),
         ('codeforiati:category-name_fr', 'category_name_fr'),
-        ('codeforiati:sector-code', 'sector_code'),
-        ('codeforiati:sector-name_en', 'sector_name_en'),
-        ('codeforiati:sector-name_fr', 'sector_name_fr'),
+        ('codeforiati:group-code', 'group_code'),
+        ('codeforiati:group-name_en', 'group_name_en'),
+        ('codeforiati:group-name_fr', 'group_name_fr'),
     ]
     Importer('SectorGroup', url, lookup)
 


### PR DESCRIPTION
Sector code needs to be the key, as otherwise only one sector is output per group (if the group is the key)