### PR TITLE
Add mapping between DAC sector categories and humanitarian clusters

### DIFF
--- a/.github/workflows/import.yml
+++ b/.github/workflows/import.yml
@@ -47,6 +47,8 @@ jobs:
             repo: Unofficial-Codelists
           - importer: sector_groups
             repo: Unofficial-Codelists
+          - importer: sector_humanitarian_cluster
+            repo: Unofficial-Codelists
     name: "Run importer: ${{ matrix.importer }}"
     runs-on: ubuntu-latest
     steps:

--- a/importers/sector_humanitarian_cluster.py
+++ b/importers/sector_humanitarian_cluster.py
@@ -4,7 +4,7 @@ from .helpers import Importer, fetch
 
 
 def run():
-    url = 'https://gist.githubusercontent.com/markbrough/57106a152dbb26a6f4544a77c6768a64/raw/1978f2094f4a80c575ed8017cd4915274f4641ed/dac5-clusters-mapping.csv'
+    url = 'https://gist.githubusercontent.com/markbrough/57106a152dbb26a6f4544a77c6768a64/raw/dac5-clusters-mapping.csv'
     lookup = [
         ('code', 'code'),
         ('name', 'name'),

--- a/importers/sector_humanitarian_cluster.py
+++ b/importers/sector_humanitarian_cluster.py
@@ -1,0 +1,19 @@
+import csv
+
+from .helpers import Importer, fetch
+
+
+def run():
+    url = 'https://gist.githubusercontent.com/markbrough/57106a152dbb26a6f4544a77c6768a64/raw/1978f2094f4a80c575ed8017cd4915274f4641ed/dac5-clusters-mapping.csv'
+    lookup = [
+        ('code', 'code'),
+        ('name', 'name'),
+        ('category', 'cluster_code'),
+        ('codeforiati:cluster', 'cluster_name'),
+    ]
+
+    Importer('SectorCategoryHumanitarianGlobalCluster', url, lookup)
+
+
+if __name__ == '__main__':
+    run()

--- a/templates/SectorCategoryHumanitarianGlobalCluster.xml
+++ b/templates/SectorCategoryHumanitarianGlobalCluster.xml
@@ -1,0 +1,14 @@
+<codelist xmlns:codeforiati="https://codeforiati.org/" name="SectorCategoryHumanitarianGlobalCluster" category-codelist="HumanitarianGlobalClusters" xml:lang="en" complete="1" embedded="0">
+    <metadata>
+        <name>
+            <narrative>DAC Sector Category and Humanitarian Cluster Mappings</narrative>
+        </name>
+        <description>
+            <narrative>Mapping between DAC Sector Categories and Humanitarian Clusters. Improvements to this codelist are welcome!</narrative>
+        </description>
+        <category>
+            <narrative>Maintained</narrative>
+        </category>
+    </metadata>
+    <codelist-items/>
+</codelist>


### PR DESCRIPTION
Fixes #50

The mapping could potentially be improved, but this is what we previously used for the [IATI/3W explorer](https://iati-3w.humportal.org/)

I'm using [this Gist](https://gist.github.com/markbrough/57106a152dbb26a6f4544a77c6768a64), which adds in codes for humanitarian clusters to this:
https://github.com/davidmegginson/iati3w-data/blob/main/inputs/dac3-sector-map.json

... which is a slightly more updated version of this:
https://github.com/davidmegginson/c19-iati-data/blob/main/data/dac3-sector-map.json