### PR TITLE
Further improvements to OrganisationRegistrationAgency

### DIFF
--- a/importers/helpers/__init__.py
+++ b/importers/helpers/__init__.py
@@ -130,7 +130,7 @@ class Importer:
         return codelist_item
 
     def source_to_xml(self):
-        etparser = ET.XMLParser(encoding='utf-8', remove_blank_text=True)
+        etparser = ET.XMLParser(encoding='utf-8', remove_blank_text=True, strip_cdata=False)
         try:
             old_xml = ET.parse(
                 join('codelist_repo', 'xml', '{}.xml'.format(self.tmpl_name)),

--- a/importers/organisation_registration_agency.py
+++ b/importers/organisation_registration_agency.py
@@ -17,8 +17,8 @@ def run():
     for registration_agency in data['lists']:
         registration_agencies.append({
             'code': registration_agency['code'],
-            'name/en': registration_agency['name']['en'],
-            'description/en': registration_agency['description']['en'],
+            'name/en': registration_agency['name']['en'].strip(),
+            'description/en': registration_agency['description']['en'].strip(),
             'access/availableOnline': {False: '0', True: '1'}[bool(registration_agency['access'].get('availableOnline', False))],
             'coverage': ",".join(registration_agency['coverage']) if registration_agency['coverage'] is not None else '',
             'url': registration_agency['url']

--- a/templates/OrganisationRegistrationAgency.xml
+++ b/templates/OrganisationRegistrationAgency.xml
@@ -2,6 +2,7 @@
     <metadata>
         <name>
             <narrative>Organisation Registration Agency</narrative>
+            <narrative xml:lang="fr">Agence d'enregistrement des organisations</narrative>
         </name>
         <description>
             <narrative><![CDATA[The values from this codelist are used to identify the particular list that an organisation identifier was drawn from. The codelist provides a register of known identifier lists, including national company registers, NGO directories and international and multilateral organisation lists - along with guidance and online resources to help locate the identifiers assigned to a specific organisation.


### PR DESCRIPTION
* Don't strip CDATA
* Strip whitespace from start and end of narrative elements
* Include missing FR translation for name of codelist